### PR TITLE
Remove SSE transport support per MCP 2025-06-18 specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ s Claude Desktop and other MCP clients with tools for Kafka Schema Registry oper
 </td>
 <td width="67%" style="vertical-align: top; padding-left: 20px;">
 
-> **🎯 True MCP Implementation**: This server uses the modern **FastMCP 2.8.0+ framework** with full **MCP 2025-06-18 specification compliance**, communicating via JSON-RPC over stdio and supporting advanced transports like SSE and HTTP. It's fully compatible with Claude Desktop and other MCP clients.
+> **🎯 True MCP Implementation**: This server uses the modern **FastMCP 2.8.0+ framework** with full **MCP 2025-06-18 specification compliance**, communicating via JSON-RPC over stdio and supporting the modern streamable-http transport. It's fully compatible with Claude Desktop and other MCP clients.
 </td>
 </tr>
 </table>
@@ -67,7 +67,7 @@ s Claude Desktop and other MCP clients with tools for Kafka Schema Registry oper
 - **Unified Server Design**: Single `kafka_schema_registry_unified_mcp.py` that auto-detects single vs multi-registry mode
 - **FastMCP 2.8.0+ Framework**: Modern MCP architecture with MCP 2025-06-18 specification compliance
 - **Enhanced Authentication**: Native FastMCP BearerAuth provider with OAuth 2.0 support for 5 identity platforms
-- **Multi-Transport Support**: stdio, SSE, and Streamable HTTP transports via FastMCP
+- **Modern Transport Support**: streamable-http transport via FastMCP (SSE transport deprecated per MCP 2025-06-18)
 - **Kafka Schema Registry Integration**: Backend for schema storage and management  
 - **KRaft Mode Support**: Works with modern Kafka without Zookeeper dependency
 - **Context-Aware Operations**: All tools support optional context parameters
@@ -446,7 +446,7 @@ Claude: Let me show you the schema-compatibility prompt which covers compatibili
 ### **🛠️ Role-Based Recommendations**
 
 | Role | Recommended Prompts |
-|------|-------------------|
+|------|---------------------|
 | **Developers** | `schema-registration`, `schema-compatibility` |
 | **DevOps Engineers** | `multi-registry`, `advanced-workflows` |
 | **Data Engineers** | `schema-export`, `context-management` |
@@ -1046,6 +1046,10 @@ Integrates with [Confluent Schema Registry](https://docs.confluent.io/platform/c
 - **Simplified Environment Variables**: Streamlined from complex provider-specific setup to generic OAuth 2.1
 - **Enhanced Security**: PKCE mandatory, improved token validation, better JWKS caching
 - **Backward Compatibility**: Legacy provider configurations automatically migrated
+- **SSE Transport Deprecation**: Removed deprecated SSE transport support per MCP 2025-06-18 specification
+  - **Modern Transport Only**: Uses streamable-http transport exclusively
+  - **Migration Guide**: Existing SSE clients should migrate to streamable-http transport
+  - **Breaking Change**: SSE transport endpoints no longer available
 - **Schema Statistics & Counting**: New tools for monitoring registry usage:
   - `count_contexts`: Track context distribution
   - `count_schemas`: Monitor schema growth

--- a/remote-mcp-server.py
+++ b/remote-mcp-server.py
@@ -11,6 +11,8 @@ making it compatible with Anthropic's remote MCP server ecosystem and OAuth 2.1 
 ✅ OAuth 2.1 COMPLIANT: Implements RFC 8692 (Protected Resource), RFC 8707 (Resource Indicators),
    PKCE enforcement, and proper security headers.
 
+✅ TRANSPORT: Uses modern streamable-http transport only (SSE transport deprecated per MCP 2025-06-18)
+
 Remote MCP servers typically expose endpoints like:
 - https://your-domain.com/mcp (for MCP protocol)
 - https://your-domain.com/health (for health checks)
@@ -578,7 +580,7 @@ async def health_check(request):
             "registry_mode": REGISTRY_MODE,
             "oauth_enabled": os.getenv("ENABLE_AUTH", "false").lower() == "true",
             "oauth_2_1_compliant": True,
-            "transport": os.getenv("MCP_TRANSPORT", "streamable-http"),
+            "transport": "streamable-http",  # Only supported transport
             "mcp_protocol_version": MCP_PROTOCOL_VERSION,
             "mcp_compliance": {
                 "header_validation_enabled": True,
@@ -866,7 +868,7 @@ async def oauth_authorization_server_metadata(request):
             # MCP-specific extensions
             "mcp_server_version": "2.0.0",
             "mcp_protocol_version": MCP_PROTOCOL_VERSION,
-            "mcp_transport": os.getenv("MCP_TRANSPORT", "streamable-http"),
+            "mcp_transport": "streamable-http",  # Only supported transport
             "mcp_endpoints": {
                 "mcp": f"{base_url}/mcp",
                 "health": f"{base_url}/health",
@@ -1022,7 +1024,7 @@ async def oauth_protected_resource_metadata(request):
                 "name": "Kafka Schema Registry MCP Server",
                 "version": "2.0.0",
                 "protocol_version": MCP_PROTOCOL_VERSION,
-                "transport": os.getenv("MCP_TRANSPORT", "streamable-http"),
+                "transport": "streamable-http",  # Only supported transport
                 "tools_count": 48,
                 "supported_registries": ["confluent", "apicurio", "hortonworks"],
                 "compliance": {
@@ -1206,16 +1208,16 @@ async def jwks_endpoint(request):
 
 
 def main():
-    """Run MCP server with remote transport configuration and OAuth 2.1 compliance."""
+    """Run MCP server with streamable-http transport only (MCP 2025-06-18 compliant)."""
 
-    # Get transport configuration from environment
-    transport = os.getenv("MCP_TRANSPORT", "streamable-http")  # Default to modern HTTP
+    # Force streamable-http transport only (SSE deprecated per MCP 2025-06-18)
+    transport = "streamable-http"
     host = os.getenv("MCP_HOST", "0.0.0.0")  # Bind to all interfaces for containers
     port = int(os.getenv("MCP_PORT", "8000"))
-    path = os.getenv("MCP_PATH", "/mcp" if transport == "streamable-http" else "/sse")
+    path = os.getenv("MCP_PATH", "/mcp")  # Always use /mcp for streamable-http
 
     logger.info("🚀 Starting Kafka Schema Registry Remote MCP Server")
-    logger.info(f"📡 Transport: {transport}")
+    logger.info(f"📡 Transport: {transport} (SSE transport deprecated per MCP 2025-06-18)")
     logger.info(f"🌐 Host: {host}")
     logger.info(f"🔌 Port: {port}")
     logger.info(f"📍 Path: {path}")
@@ -1247,16 +1249,9 @@ def main():
         os.environ["UVICORN_HOST"] = host
         os.environ["UVICORN_PORT"] = str(port)
 
-        if transport == "streamable-http":
-            # Modern HTTP transport (recommended)
-            mcp.run(transport="streamable-http")
-        elif transport == "sse":
-            # SSE transport (compatible with existing SSE clients)
-            mcp.run(transport="sse")
-        else:
-            logger.error(f"Unsupported transport: {transport}")
-            logger.info("Supported transports: streamable-http, sse")
-            return 1
+        # Only streamable-http transport is supported (SSE deprecated per MCP 2025-06-18)
+        logger.info("🚀 Starting MCP server with streamable-http transport")
+        mcp.run(transport="streamable-http")
 
     except Exception as e:
         logger.error(f"Failed to start remote MCP server: {e}")


### PR DESCRIPTION
## Description
This PR removes SSE (Server-Sent Events) transport support from the Kafka Schema Registry MCP Server in compliance with the MCP 2025-06-18 specification, which deprecates SSE transport in favor of the modern streamable-http transport.

## Changes Made

### Code Changes
- **`remote-mcp-server.py`**: 
  - Removed SSE transport option from main function 
  - Force streamable-http transport only
  - Updated configuration defaults
  - Updated health check to reflect only streamable-http support
  - Updated OAuth metadata endpoints to reflect transport change
  - Updated logging messages to indicate SSE deprecation
  - Removed SSE-specific path logic

### Documentation Updates
- **`README.md`**:
  - Remove reference to SSE in MCP implementation description
  - Update architecture section to reflect SSE transport deprecation
  - Add note about SSE transport removal in v2.0.x changelog
  - Update transport support description to reflect modern streamable-http only
  - Add migration note for existing SSE clients

## Breaking Changes ⚠️
- **SSE transport endpoints are no longer available**
- **Existing SSE clients must migrate to streamable-http transport**
- Environment variable `MCP_TRANSPORT` is ignored and forced to `streamable-http`

## Migration Guide for SSE Clients
Existing SSE clients should:
1. Update client configuration to use streamable-http transport
2. Update endpoints from `/sse` to `/mcp`
3. Ensure MCP-Protocol-Version header is included in requests
4. Test compatibility with the new transport

## Compliance
- ✅ **MCP 2025-06-18 Specification Compliant**
- ✅ **Maintains OAuth 2.1 Support**
- ✅ **No Impact on Schema Registry Operations**
- ✅ **Backward Compatible** (except for transport layer)

## Testing
- [x] Server starts successfully with streamable-http transport only
- [x] All MCP tools function correctly
- [x] OAuth endpoints work as expected  
- [x] Health checks reflect transport changes
- [x] Documentation updated appropriately

Closes #38