### PR TITLE
security: require jaraco-context>=6.1.0 (GHSA-58pv-8j8x-9vj2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to the Kafka Schema Registry MCP Server will be documented i
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.1] - 2026-04-06
+
+### Security
+
+- Require `jaraco-context>=6.1.0` to address GHSA-58pv-8j8x-9vj2 (path traversal; transitive via FastMCP → keyring stack).
+
+### Added
+
+- Contributor onboarding: [GETTING_STARTED.md](GETTING_STARTED.md) and [QUICK_REFERENCE.md](QUICK_REFERENCE.md).
+- Claude Code project assets under `.claude-code/` (configuration, workspace hints, Avro schema templates, skill docs) and related README updates.
+
+### Changed
+
+- Declare the FastMCP **`tasks`** extra in `pyproject.toml` and `requirements.txt` so installs consistently include background-task support; add explicit `pydocket>=0.18.0` for FastMCP 3.x / constrained install paths.
+- Demo MCP bridge: bump pinned FastAPI and `python-multipart` in [demo/requirements-bridge.txt](demo/requirements-bridge.txt).
+- GitHub Actions: routine version bumps across workflows (artifacts, Docker actions, Helm setup, etc.).
+- Local unified tests: [tests/docker-compose.yml](tests/docker-compose.yml) `pull_policy` adjusted for local image builds.
+
+### Fixed
+
+- Minor formatting cleanup in `tests/fix_registry_modes.py` (Black).
+
 ## [2.2.0] - 2026-01-02
 
 ### 🚀 MCP Protocol 2025-11-25 Compliance & FastMCP Background Tasks API

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "PyJWT>=2.10.0",
     "cryptography>=45.0.0",
     "avro-python3>=1.10.0",
+    "jaraco-context>=6.1.0",  # GHSA-58pv-8j8x-9vj2 (transitive via fastmcp/keyring)
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,8 @@
 fastmcp[tasks]>=2.14.0
 # Explicit pydocket: FastMCP 3.x gates task=True on import docket (tasks extra); ensures Docker/pip edge cases install it
 pydocket>=0.18.0
+# Transitive via fastmcp -> py-key-value-aio[keyring] -> keyring; GHSA-58pv-8j8x-9vj2 path traversal fixed in 6.1.0+
+jaraco-context>=6.1.0
 
 # MCP Python SDK - CVE-2025-66416: DNS rebinding protection requires >=1.23.0
 mcp>=1.23.0

--- a/uv.lock
+++ b/uv.lock
@@ -829,14 +829,14 @@ wheels = [
 
 [[package]]
 name = "jaraco-context"
-version = "6.0.2"
+version = "6.1.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "backports-tarfile", marker = "python_full_version < '3.12'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8d/7d/41acf8e22d791bde812cb6c2c36128bb932ed8ae066bcb5e39cb198e8253/jaraco_context-6.0.2.tar.gz", hash = "sha256:953ae8dddb57b1d791bf72ea1009b32088840a7dd19b9ba16443f62be919ee57", size = 14994, upload-time = "2025-12-24T19:21:35.784Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/50/4763cd07e722bb6285316d390a164bc7e479db9d90daa769f22578f698b4/jaraco_context-6.1.2.tar.gz", hash = "sha256:f1a6c9d391e661cc5b8d39861ff077a7dc24dc23833ccee564b234b81c82dfe3", size = 16801, upload-time = "2026-03-20T22:13:33.922Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/0c/1e0096ced9c55f9c6c6655446798df74165780375d3f5ab5f33751e087ae/jaraco_context-6.0.2-py3-none-any.whl", hash = "sha256:55fc21af4b4f9ca94aa643b6ee7fe13b1e4c01abf3aeb98ca4ad9c80b741c786", size = 6988, upload-time = "2025-12-24T19:21:34.557Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/58/bc8954bda5fcda97bd7c19be11b85f91973d67a706ed4a3aec33e7de22db/jaraco_context-6.1.2-py3-none-any.whl", hash = "sha256:bf8150b79a2d5d91ae48629d8b427a8f7ba0e1097dd6202a9059f29a36379535", size = 7871, upload-time = "2026-03-20T22:13:32.808Z" },
 ]
 
 [[package]]
@@ -913,6 +913,7 @@ dependencies = [
     { name = "cryptography" },
     { name = "fastmcp" },
     { name = "httpx" },
+    { name = "jaraco-context" },
     { name = "jsonschema" },
     { name = "mcp" },
     { name = "pyjwt" },
@@ -936,8 +937,9 @@ requires-dist = [
     { name = "avro-python3", specifier = ">=1.10.0" },
     { name = "black", marker = "extra == 'dev'", specifier = ">=23.0.0" },
     { name = "cryptography", specifier = ">=45.0.0" },
-    { name = "fastmcp", specifier = ">=2.14.0" },
+    { name = "fastmcp", extras = ["tasks"], specifier = ">=2.14.0" },
     { name = "httpx", specifier = ">=0.25.2" },
+    { name = "jaraco-context", specifier = ">=6.1.0" },
     { name = "jsonschema", specifier = ">=4.24.0" },
     { name = "mcp", specifier = ">=1.23.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.5.0" },


### PR DESCRIPTION
Pin transitive jaraco.context pulled via fastmcp -> py-key-value-aio[keyring] -> keyring. setuptools still vendors 5.3.0 under site-packages; explicit pin ensures pip installs patched release in Docker/CI.

Refs: https://github.com/aywengo/kafka-schema-reg-mcp/issues/130