### PR TITLE
chore(security): consolidate dependency updates and fix Trivy findings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
       interval: "weekly"
       day: "monday"
       time: "06:00"
-    open-pull-requests-limit: 12
+    open-pull-requests-limit: 5
     labels:
       - "dependencies"
       - "version-update"
@@ -15,6 +15,13 @@ updates:
     commit-message:
       prefix: "deps"
       include: "scope"
+    groups:
+      python-dependencies:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
     # Only allow patch and minor version updates (excludes major security updates)
     allow:
       - dependency-type: "direct"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
       contents: read
       security-events: write  # Required for SARIF upload
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4

--- a/.github/workflows/docker-security-scan.yml
+++ b/.github/workflows/docker-security-scan.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -79,72 +79,102 @@ jobs:
             --scanners vuln \
             kafka-schema-registry-mcp:security-scan | tee trivy-table.txt
 
-      - name: Create issue from vulnerabilities
+      - name: Manage security scan issues
         if: github.event_name == 'schedule'
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');
             const trivyOutput = fs.readFileSync('trivy-table.txt', 'utf8');
-            
-            // Check if there are any vulnerabilities
-            if (trivyOutput.includes('Total: 0')) {
-              console.log('No HIGH or CRITICAL vulnerabilities found');
-              return;
-            }
-            
-            // Check for CRITICAL and HIGH vulnerabilities specifically
+
             const hasCritical = trivyOutput.includes('CRITICAL');
             const hasHigh = trivyOutput.includes('HIGH');
-            
-            if (!hasCritical && !hasHigh) {
+            const hasFindings = hasCritical || hasHigh;
+
+            const { data: openIssues } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'security,automated',
+              per_page: 20,
+            });
+
+            const existingIssue = openIssues.find((issue) =>
+              issue.title.includes('Security Scan Alert')
+            );
+
+            if (!hasFindings) {
               console.log('No HIGH or CRITICAL vulnerabilities found');
+              for (const issue of openIssues.filter((item) => item.title.includes('Security Scan Alert'))) {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  body: `## Clean scan — ${new Date().toISOString()}\n\nNo HIGH or CRITICAL vulnerabilities with available fixes were found. Closing this issue.`,
+                });
+                await github.rest.issues.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  state: 'closed',
+                  state_reason: 'completed',
+                });
+              }
               return;
             }
-            
-            // Create issue body
-            const issueBody = `## 🔒 Security Scan Results
-            
+
+            const issueBody = `## Security Scan Results
+
             The scheduled security scan found HIGH or CRITICAL vulnerabilities in the Docker image.
-            
+
             ### Scan Details
             - **Date**: ${new Date().toISOString()}
             - **Image**: kafka-schema-registry-mcp
             - **Scanner**: Trivy
             - **Severity Filter**: CRITICAL and HIGH only (MEDIUM and LOW excluded)
             - **Configuration**: Unfixed vulnerabilities are ignored
-            
+
             ### Vulnerabilities Found
-            
+
             \`\`\`
             ${trivyOutput}
             \`\`\`
-            
+
             **Note**: This scan excludes:
             - MEDIUM and LOW severity issues per security policy
             - Vulnerabilities without available fixes
-            
+
             Only CRITICAL and HIGH severity vulnerabilities with available fixes are reported.
-            
+
             ### Recommended Actions
             1. Review the vulnerabilities listed above
             2. Update base images if newer versions are available
             3. Update dependencies in requirements.txt
             4. Apply security patches where possible
             5. Add to .trivyignore if vulnerabilities are not exploitable in our context
-            
+
             ### Resources
             - [Trivy Documentation](https://aquasecurity.github.io/trivy/)
             - [Docker Security Best Practices](https://docs.docker.com/develop/security-best-practices/)
             `;
-            
-            // Create the issue
+
+            if (existingIssue) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existingIssue.number,
+                body: `## Updated scan — ${new Date().toISOString()}\n\n${issueBody}`,
+              });
+              console.log(`Updated existing security issue #${existingIssue.number}`);
+              return;
+            }
+
             await github.rest.issues.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              title: `🔒 Security Scan Alert - HIGH/CRITICAL Vulnerabilities - ${new Date().toLocaleDateString()}`,
+              title: `Security Scan Alert - HIGH/CRITICAL Vulnerabilities - ${new Date().toLocaleDateString()}`,
               body: issueBody,
-              labels: ['security', 'docker', 'automated', 'high-priority']
+              labels: ['security', 'docker', 'automated', 'high-priority'],
             });
 
       - name: Generate scan summary

--- a/.github/workflows/inspector-tests.yml
+++ b/.github/workflows/inspector-tests.yml
@@ -24,7 +24,7 @@ jobs:
     
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
     
     - name: Set up Node.js
       uses: actions/setup-node@v6
@@ -85,7 +85,7 @@ jobs:
     
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
     
     - name: Set up Node.js
       uses: actions/setup-node@v6

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
       security-events: write  # Required for SARIF upload
       id-token: write  # Required for attestation
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -164,7 +164,7 @@ jobs:
     permissions:
       contents: write  # Required to create releases
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Extract changelog section
         id: changelog
@@ -206,7 +206,7 @@ jobs:
           echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ github.ref_name }}
           name: Release ${{ github.ref_name }}

--- a/.github/workflows/release-helm-chart.yml
+++ b/.github/workflows/release-helm-chart.yml
@@ -20,7 +20,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -82,19 +82,19 @@ jobs:
       id-token: write
     steps:
       - name: Checkout gh-pages
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: gh-pages
           path: gh-pages
 
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v5
         with:
           path: gh-pages
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4 
+        uses: actions/deploy-pages@v5 

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -24,7 +24,7 @@ jobs:
       
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       
     - name: Build Docker image
       run: |
@@ -83,7 +83,7 @@ jobs:
         scanners: 'vuln'
         
     - name: Process Trivy results and create issue if critical vulnerabilities found
-      uses: actions/github-script@v8
+      uses: actions/github-script@v9
       if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop'
       with:
         script: |
@@ -258,7 +258,7 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       
     - name: Run Docker Bench Security
       run: |
@@ -288,7 +288,7 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       
     - name: Set up Python
       uses: actions/setup-python@v6
@@ -341,7 +341,7 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         fetch-depth: 0
         

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event.inputs.test_mode != 'docker-only' }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -55,10 +55,13 @@ jobs:
         run: |
           isort --check-only --diff *.py tests/*.py
 
+      - name: Check dependency pin parity
+        run: python scripts/check-deps-parity.py
+
   docker-build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -166,7 +169,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event.inputs.test_mode == 'quick' || (github.event.inputs.test_mode != 'full' && github.event.inputs.test_mode != 'lint-only' && github.event.inputs.test_mode != 'docker-only') }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -227,7 +230,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event.inputs.test_mode == 'full' }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -281,7 +284,7 @@ jobs:
           python -m pytest --cov=.. --cov-report=xml --cov-report=html -v
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           files: ./tests/coverage.xml
           flags: unittests
@@ -307,7 +310,7 @@ jobs:
     if: ${{ github.event.inputs.test_mode != 'lint-only' }}
     needs: docker-build
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to the Kafka Schema Registry MCP Server will be documented i
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.2] - 2026-08-22
+
+### Security
+
+- Pin `setuptools>=78.1.1` in Docker builder stage to address CVE-2025-47273 (path traversal in PackageIndex).
+- Pin `msgpack>=1.2.1` to address GHSA-6v7p-g79w-8964 (transitive via pydocket/redis stack).
+- Strip pip/setuptools/wheel from production Docker image to eliminate pip-vendored msgpack scan noise.
+- Consolidated dependency floor bumps from Dependabot PRs #147–#166 (superseded by this release).
+
+### Changed
+
+- Sync `requirements.txt` and `pyproject.toml` dependency floors (aiohttp, requests, fastmcp, cryptography, python-dotenv, jsonschema, jaraco-context, fastapi).
+- Bump GitHub Actions: checkout v7, configure-pages v6, deploy-pages v5, github-script v9, upload-pages-artifact v5, action-gh-release v3, codecov-action v7.
+- Demo MCP bridge: bump FastAPI, uvicorn, and python-multipart in [demo/requirements-bridge.txt](demo/requirements-bridge.txt).
+- Dependabot: group pip dependency updates into weekly consolidated PRs.
+- Docker security scan workflow: comment on existing open security issue instead of creating duplicates; auto-close when scan is clean.
+
+### Added
+
+- CI check script [scripts/check-deps-parity.py](scripts/check-deps-parity.py) to keep `requirements.txt` and `pyproject.toml` pins aligned.
+
 ## [2.2.1] - 2026-04-06
 
 ### Security

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y \
 
 # Copy requirements and install Python dependencies in builder stage
 COPY requirements.txt .
-RUN pip install --no-cache-dir --upgrade pip setuptools wheel && \
+RUN pip install --no-cache-dir --upgrade "pip>=25.0" "setuptools>=78.1.1" wheel && \
     pip install --no-cache-dir -r requirements.txt
 
 # Production stage with minimal attack surface
@@ -83,6 +83,12 @@ RUN chown -R mcp:mcp /app
 # Copy Python packages from builder stage
 COPY --from=builder /usr/local/lib/python3.14/site-packages /usr/local/lib/python3.14/site-packages
 COPY --from=builder /usr/local/bin /usr/local/bin
+
+# Remove pip/setuptools/wheel from runtime image (not needed; pip vendors msgpack 1.1.2)
+RUN rm -rf /usr/local/lib/python3.14/site-packages/pip* \
+    /usr/local/lib/python3.14/site-packages/setuptools* \
+    /usr/local/lib/python3.14/site-packages/wheel* \
+    && rm -f /usr/local/bin/pip /usr/local/bin/pip3 /usr/local/bin/pip3.14 2>/dev/null || true
 
 # Copy core application modules with proper ownership
 COPY --chown=mcp:mcp oauth_provider.py .

--- a/demo/requirements-bridge.txt
+++ b/demo/requirements-bridge.txt
@@ -1,8 +1,8 @@
-fastapi==0.135.1
-uvicorn[standard]==0.40.0
+fastapi==0.135.3
+uvicorn[standard]==0.44.0
 httpx==0.28.1
 pydantic==2.12.5
-python-multipart==0.0.22
+python-multipart==0.0.26
 aiofiles==23.2.1
 python-json-logger==2.0.7
 asyncio-mqtt==0.16.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kafka-schema-registry-mcp"
-version = "2.0.0"
+version = "2.2.2"
 description = "A Model Context Protocol (MCP) server for Kafka Schema Registry - enables AI assistants to interact with Kafka schemas through a standardized interface"
 authors = [
     {name = "Kafka Schema Registry MCP Team", email = ""},
@@ -10,24 +10,26 @@ license = {text = "MIT"}
 requires-python = ">=3.10"
 dependencies = [
     "aiofiles>=23.2.1,<25.0.0",
-    "httpx>=0.25.2",
-    "fastmcp[tasks]>=2.14.0",
+    "httpx>=0.27.0",
+    "fastmcp[tasks]>=2.14.7",
+    "pydocket>=0.18.0",
     "mcp>=1.23.0",  # CVE-2025-66416: DNS rebinding protection
-    "requests>=2.31.0",
-    "python-dotenv>=1.0.0",
-    "aiohttp>=3.12.13",
-    "jsonschema>=4.24.0",
-    "PyJWT>=2.10.0",
-    "cryptography>=45.0.0",
-    "avro-python3>=1.10.0",
-    "jaraco-context>=6.1.0",  # GHSA-58pv-8j8x-9vj2 (transitive via fastmcp/keyring)
+    "requests>=2.33.1",
+    "python-dotenv>=1.2.2",
+    "aiohttp>=3.13.5",
+    "jsonschema>=4.26.0",
+    "PyJWT>=2.10.1",
+    "cryptography>=45.0.7",
+    "avro-python3>=1.10.2",
+    "jaraco-context>=6.1.2",  # GHSA-58pv-8j8x-9vj2 (transitive via fastmcp/keyring)
+    "msgpack>=1.2.1",  # GHSA-6v7p-g79w-8964 (transitive via pydocket/redis stack)
 ]
 
 [project.optional-dependencies]
 dev = [
     "pytest>=7.4.0",
-    "black>=23.0.0",
-    "ruff>=0.1.0",
+    "black>=23.12.1",
+    "ruff>=0.15.10",
     "mypy>=1.5.0",
     "pytest-asyncio>=0.21.0",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,28 +1,30 @@
 # FastMCP 2.14.0+ for MCP 2025-11-25 specification compliance with background tasks support
-fastmcp[tasks]>=2.14.0
+fastmcp[tasks]>=2.14.7
 # Explicit pydocket: FastMCP 3.x gates task=True on import docket (tasks extra); ensures Docker/pip edge cases install it
 pydocket>=0.18.0
 # Transitive via fastmcp -> py-key-value-aio[keyring] -> keyring; GHSA-58pv-8j8x-9vj2 path traversal fixed in 6.1.0+
-jaraco-context>=6.1.0
+jaraco-context>=6.1.2
+# Transitive via pydocket/redis stack; GHSA-6v7p-g79w-8964 out-of-bounds read fixed in 1.2.1+
+msgpack>=1.2.1
 
 # MCP Python SDK - CVE-2025-66416: DNS rebinding protection requires >=1.23.0
 mcp>=1.23.0
 
 # FastAPI for MCP-Protocol-Version header validation middleware
-fastapi>=0.115.0
+fastapi>=0.135.3
 
 # Kafka Schema Registry integration - Updated to latest secure versions
-requests>=2.32.4
-python-dotenv>=1.1.1
-aiohttp>=3.12.13
+requests>=2.33.1
+python-dotenv>=1.2.2
+aiohttp>=3.13.5
 
 # OAuth JWT validation dependencies - Updated to latest secure versions
 PyJWT>=2.10.1
-cryptography>=45.0.4
+cryptography>=45.0.7
 
 # Data processing for export functionality - Using known stable versions
 avro-python3>=1.10.2
-jsonschema>=4.24.0
+jsonschema>=4.26.0
 
 # FastMCP web framework for remote deployment - Conservative version
 starlette>=0.27.0

--- a/scripts/check-deps-parity.py
+++ b/scripts/check-deps-parity.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Verify overlapping dependency floor pins match between requirements.txt and pyproject.toml."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+REQUIREMENTS = ROOT / "requirements.txt"
+PYPROJECT = ROOT / "pyproject.toml"
+
+REQ_PATTERN = re.compile(
+    r"^([a-zA-Z0-9_.\-\[\]]+)(?:\[[^\]]+\])?\s*(>=|==|~=|<=|<|!=)\s*([^\s#,]+)",
+    re.MULTILINE,
+)
+TOML_DEP_PATTERN = re.compile(
+    r'"([a-zA-Z0-9_.\-\[\]]+)(?:\[[^\]]+\])?\s*(>=|==|~=|<=|<|!=)\s*([^"]+)"',
+)
+
+
+def normalize_name(name: str) -> str:
+    """Normalize package names for comparison (ignore extras)."""
+    return name.split("[", 1)[0].lower().replace("_", "-")
+
+
+def parse_requirements(path: Path) -> dict[str, str]:
+    """Parse floor pins from requirements.txt."""
+    pins: dict[str, str] = {}
+    for line in path.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        match = REQ_PATTERN.match(stripped)
+        if not match:
+            continue
+        name, op, version = match.groups()
+        if op == ">=":
+            pins[normalize_name(name)] = version
+    return pins
+
+
+def parse_pyproject(path: Path) -> dict[str, str]:
+    """Parse floor pins from pyproject.toml [project].dependencies."""
+    text = path.read_text(encoding="utf-8")
+    start = text.find("dependencies = [")
+    if start == -1:
+        return {}
+    optional_start = text.find("[project.optional-dependencies]", start)
+    if optional_start == -1:
+        optional_start = text.find("[project.urls]", start)
+    if optional_start == -1:
+        optional_start = len(text)
+    block = text[start:optional_start]
+    pins: dict[str, str] = {}
+    for match in TOML_DEP_PATTERN.finditer(block):
+        name, op, version = match.groups()
+        if op == ">=":
+            base_version = version.split(",", 1)[0].strip()
+            pins[normalize_name(name)] = base_version
+    return pins
+
+
+def main() -> int:
+    req_pins = parse_requirements(REQUIREMENTS)
+    py_pins = parse_pyproject(PYPROJECT)
+    shared = sorted(set(req_pins) & set(py_pins))
+    mismatches: list[str] = []
+
+    for name in shared:
+        req_version = req_pins[name]
+        py_version = py_pins[name]
+        if req_version != py_version:
+            mismatches.append(f"{name}: requirements.txt>={req_version} vs pyproject.toml>={py_version}")
+
+    if mismatches:
+        print("Dependency pin mismatches between requirements.txt and pyproject.toml:")
+        for item in mismatches:
+            print(f"  - {item}")
+        return 1
+
+    print(f"OK: {len(shared)} shared dependency floor pins match.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci-lint-check.sh
+++ b/scripts/ci-lint-check.sh
@@ -99,6 +99,16 @@ if ! run_ci_check "isort import sorting" \
     CRITICAL_FAILED=true
 fi
 
+# Step 6: Dependency pin parity (CRITICAL - will fail CI)
+echo -e "\n${BLUE}=== STEP 6: Dependency Pin Parity ===${NC}"
+echo "This check will FAIL CI if requirements.txt and pyproject.toml pins diverge"
+
+if ! run_ci_check "Dependency pin parity" \
+    "python scripts/check-deps-parity.py" \
+    true; then
+    CRITICAL_FAILED=true
+fi
+
 # Summary
 echo -e "\n${BLUE}=== SUMMARY ===${NC}"
 if [[ "${CRITICAL_FAILED:-false}" == "true" ]]; then


### PR DESCRIPTION
## Summary
- Pin `msgpack>=1.2.1` (GHSA-6v7p-g79w-8964) and `setuptools>=78.1.1` (CVE-2025-47273) in Docker build
- Strip pip/setuptools/wheel from production image to eliminate pip-vendored msgpack scan noise
- Consolidate all open Dependabot floor bumps (#147–#166) into one update for `requirements.txt` and `pyproject.toml`
- Bump GitHub Actions (checkout v7, codecov v7, pages actions, github-script v9, etc.)
- Deduplicate weekly Trivy security issues (comment on existing issue instead of creating new ones)
- Add `scripts/check-deps-parity.py` CI check and Dependabot pip grouping

## Test plan
- [x] `./scripts/ci-lint-check.sh` passes
- [x] `python scripts/check-deps-parity.py` — 13 shared pins match
- [x] Docker build succeeds
- [x] Trivy scan: 0 HIGH/CRITICAL with fixes available
- [x] MCP module imports in production image

## Supersedes
Closes/supersedes Dependabot PRs #147–#166. After merge, security issues #167–#169 should be closed.

Made with [Cursor](https://cursor.com)