### PR TITLE
fix: FastMCP 3.4 compat (JWTVerifier, list_tools)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Align current-facing docs and README with FastMCP 3.2.0+ (3.x, capped below 4) and MCP 2025-11-25 (no longer advertise FastMCP 2.8 / MCP 2025-06-18 as current).
+- FastMCP 3.4 compatibility: replace removed `BearerAuthProvider` with `JWTVerifier`, prefer `list_tools()`, and pass host/port/path into `mcp.run()` ([#177](https://github.com/aywengo/kafka-schema-reg-mcp/issues/177) Phase 1).
 
 ## [2.2.2] - 2026-08-22
 

--- a/docs/oauth-providers-guide.md
+++ b/docs/oauth-providers-guide.md
@@ -47,6 +47,10 @@ export AUTH_ISSUER_URL="https://your-oauth-provider.com"
 # Set your client ID or API identifier
 export AUTH_AUDIENCE="your-client-id-or-api-identifier"
 
+# FastMCP 3 JWTVerifier: JWKS URI (default `{issuer}/.well-known/jwks.json`).
+# Set this for Keycloak and other providers whose JWKS is not at that path.
+# export AUTH_JWKS_URI="https://your-oauth-provider.com/.well-known/jwks.json"
+
 # Optional: Configure scopes (defaults shown)
 export AUTH_VALID_SCOPES="read,write,admin"
 export AUTH_DEFAULT_SCOPES="read"
@@ -71,6 +75,7 @@ export AUTH_AUDIENCE="your-client-id.apps.googleusercontent.com"
 ```bash
 export AUTH_ISSUER_URL="https://your-keycloak-server.com/realms/your-realm"
 export AUTH_AUDIENCE="your-keycloak-client-id"
+export AUTH_JWKS_URI="https://your-keycloak-server.com/realms/your-realm/protocol/openid-connect/certs"
 ```
 
 #### 🟧 Okta
@@ -197,6 +202,7 @@ export AUTH_AUDIENCE="YOUR_CLIENT_ID.apps.googleusercontent.com"
 export ENABLE_AUTH=true
 export AUTH_ISSUER_URL="https://your-keycloak-server.com/realms/your-realm"
 export AUTH_AUDIENCE="mcp-schema-registry"
+export AUTH_JWKS_URI="https://your-keycloak-server.com/realms/your-realm/protocol/openid-connect/certs"
 ```
 
 ### 🟧 Okta

--- a/oauth_provider.py
+++ b/oauth_provider.py
@@ -840,7 +840,7 @@ if ENABLE_AUTH:
                 oauth_provider = OAuth21BearerAuthProvider()
                 logger.info("OAuth 2.1 JWT verifier initialized successfully")
             except Exception as e:
-                logger.warning(f"Failed to initialize OAuth 2.1 Bearer Auth Provider: {e}")
+                logger.warning(f"Failed to initialize OAuth 2.1 JWT verifier: {e}")
                 oauth_provider = None
         else:
             oauth_provider = None

--- a/oauth_provider.py
+++ b/oauth_provider.py
@@ -78,6 +78,9 @@ AUTH_REVOCATION_ENABLED = os.getenv("AUTH_REVOCATION_ENABLED", "true").lower() i
 
 # OAuth 2.1 Configuration (generic approach)
 AUTH_AUDIENCE = os.getenv("AUTH_AUDIENCE", "")  # Client ID or API identifier
+# FastMCP 3 JWTVerifier requires public_key or jwks_uri (BearerAuthProvider was removed).
+AUTH_JWKS_URI = os.getenv("AUTH_JWKS_URI", "")
+AUTH_PUBLIC_KEY = os.getenv("AUTH_PUBLIC_KEY", "")
 
 # Legacy GitHub OAuth Configuration (for backward compatibility)
 AUTH_GITHUB_CLIENT_ID = os.getenv("AUTH_GITHUB_CLIENT_ID", "")
@@ -736,14 +739,38 @@ class OAuth21TokenValidator:
 # Global token validator instance
 token_validator = OAuth21TokenValidator() if JWT_AVAILABLE else None
 
+
+def _fastmcp_jwt_verifier_kwargs() -> Dict[str, Any]:
+    """Build FastMCP 3 JWTVerifier kwargs (replaces removed BearerAuthProvider)."""
+    audience: Union[str, List[str], None]
+    if AUTH_AUDIENCE:
+        audience = AUTH_AUDIENCE
+    elif RESOURCE_INDICATORS:
+        audience = RESOURCE_INDICATORS
+    else:
+        audience = None
+
+    kwargs: Dict[str, Any] = {
+        "issuer": AUTH_ISSUER_URL,
+        "audience": audience,
+        "required_scopes": AUTH_REQUIRED_SCOPES,
+    }
+    if AUTH_PUBLIC_KEY:
+        kwargs["public_key"] = AUTH_PUBLIC_KEY
+    else:
+        issuer = AUTH_ISSUER_URL.rstrip("/")
+        kwargs["jwks_uri"] = AUTH_JWKS_URI or f"{issuer}/.well-known/jwks.json"
+    return kwargs
+
+
 if ENABLE_AUTH:
     try:
-        from fastmcp.server.auth import BearerAuthProvider
+        from fastmcp.server.auth import JWTVerifier
         from fastmcp.server.dependencies import AccessToken, get_access_token
 
-        class OAuth21BearerAuthProvider(BearerAuthProvider):
+        class OAuth21BearerAuthProvider(JWTVerifier):
             """
-            OAuth 2.1 compliant Bearer Auth Provider for MCP Server.
+            OAuth 2.1 JWT verifier for the MCP server (FastMCP 3 JWTVerifier).
 
             Implements comprehensive OAuth 2.1 features:
             - PKCE enforcement (mandatory)
@@ -756,21 +783,18 @@ if ENABLE_AUTH:
             """
 
             def __init__(self, **kwargs):
-                # Use standard OAuth 2.1 configuration - let discovery handle the details
-                super().__init__(
-                    issuer=AUTH_ISSUER_URL,
-                    audience=AUTH_AUDIENCE or RESOURCE_INDICATORS,
-                    required_scopes=AUTH_REQUIRED_SCOPES,
-                    **kwargs,
-                )
+                init_kwargs = _fastmcp_jwt_verifier_kwargs()
+                init_kwargs.update(kwargs)
+                super().__init__(**init_kwargs)
 
                 self.valid_scopes = set(AUTH_VALID_SCOPES)
                 self.required_scopes = set(AUTH_REQUIRED_SCOPES)
-                logger.info(f"OAuth 2.1 Bearer Auth Provider initialized with scopes: {self.valid_scopes}")
+                logger.info(f"OAuth 2.1 JWT verifier initialized with scopes: {self.valid_scopes}")
                 logger.info(f"JWT validation available: {JWT_AVAILABLE}")
                 logger.info(f"PKCE enforcement: {REQUIRE_PKCE}")
                 logger.info(f"Resource indicators: {RESOURCE_INDICATORS}")
                 logger.info(f"OAuth 2.1 Issuer: {AUTH_ISSUER_URL}")
+                logger.info(f"JWKS URI: {self.jwks_uri}")
                 logger.info(f"SSL/TLS verification: {ENFORCE_SSL_TLS_VERIFICATION}")
                 logger.info(
                     "🚀 Using generic OAuth 2.1 discovery (RFC 8414) - no provider-specific configuration needed"
@@ -792,7 +816,8 @@ if ENABLE_AUTH:
                 """Check if user has required scopes, considering scope hierarchy."""
                 if token_validator:
                     return token_validator.check_scopes(user_scopes, required_scopes)
-                return super().check_scopes(user_scopes, required_scopes)
+                expanded = self.expand_scopes(list(user_scopes))
+                return required_scopes.issubset(expanded)
 
             def expand_scopes(self, scopes: list) -> Set[str]:
                 """Expand scopes to include inherited scopes based on hierarchy."""
@@ -813,7 +838,7 @@ if ENABLE_AUTH:
         if JWT_AVAILABLE:
             try:
                 oauth_provider = OAuth21BearerAuthProvider()
-                logger.info("OAuth 2.1 Bearer Auth Provider initialized successfully")
+                logger.info("OAuth 2.1 JWT verifier initialized successfully")
             except Exception as e:
                 logger.warning(f"Failed to initialize OAuth 2.1 Bearer Auth Provider: {e}")
                 oauth_provider = None

--- a/remote-mcp-server.py
+++ b/remote-mcp-server.py
@@ -1191,7 +1191,7 @@ def main():
 
         # Only streamable-http transport is supported (SSE deprecated per MCP 2025-06-18)
         logger.info("🚀 Starting MCP server with streamable-http transport")
-        mcp.run(transport="streamable-http")
+        mcp.run(transport="streamable-http", host=host, port=port, path=path)
 
     except Exception as e:
         logger.error(f"Failed to start remote MCP server: {e}")

--- a/tests/test_fastmcp3_compat.py
+++ b/tests/test_fastmcp3_compat.py
@@ -1,0 +1,46 @@
+"""FastMCP 3.4 compatibility checks (issue #177 Phase 1)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastmcp.server.auth.providers.jwt import JWTVerifier
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import oauth_provider
+from kafka_schema_registry_unified_mcp import mcp
+
+
+def test_bearer_auth_provider_is_gone() -> None:
+    """FastMCP 3 removed BearerAuthProvider; JWTVerifier is the replacement."""
+    import fastmcp.server.auth as auth
+
+    assert not hasattr(auth, "BearerAuthProvider")
+    assert JWTVerifier is not None
+
+
+def test_server_lists_tools_via_list_tools() -> None:
+    """FastMCP 3 uses list_tools() (list of Tool), not get_tools() (dict)."""
+    assert hasattr(mcp, "list_tools")
+    assert not hasattr(mcp, "get_tools")
+
+
+@pytest.mark.asyncio
+async def test_list_tools_returns_named_tools() -> None:
+    tools = await mcp.list_tools()
+    assert isinstance(tools, list)
+    assert len(tools) >= 20
+    names = {t.name for t in tools if getattr(t, "name", None)}
+    assert "ping" in names
+
+
+def test_jwt_verifier_accepts_project_kwargs() -> None:
+    """JWTVerifier must construct from our FastMCP 3 helper kwargs."""
+    kwargs: dict[str, Any] = oauth_provider._fastmcp_jwt_verifier_kwargs()
+    assert "jwks_uri" in kwargs or "public_key" in kwargs
+    verifier = JWTVerifier(**kwargs)
+    assert verifier.issuer == oauth_provider.AUTH_ISSUER_URL

--- a/tests/test_fastmcp3_compat.py
+++ b/tests/test_fastmcp3_compat.py
@@ -3,11 +3,12 @@
 from __future__ import annotations
 
 import sys
+from collections.abc import Sequence
 from pathlib import Path
 from typing import Any
 
 import pytest
-from fastmcp.server.auth.providers.jwt import JWTVerifier
+from fastmcp.server.auth import JWTVerifier
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
@@ -24,7 +25,7 @@ def test_bearer_auth_provider_is_gone() -> None:
 
 
 def test_server_lists_tools_via_list_tools() -> None:
-    """FastMCP 3 uses list_tools() (list of Tool), not get_tools() (dict)."""
+    """FastMCP 3 uses list_tools() (Sequence[Tool]), not get_tools() (dict)."""
     assert hasattr(mcp, "list_tools")
     assert not hasattr(mcp, "get_tools")
 
@@ -32,8 +33,8 @@ def test_server_lists_tools_via_list_tools() -> None:
 @pytest.mark.asyncio
 async def test_list_tools_returns_named_tools() -> None:
     tools = await mcp.list_tools()
-    assert isinstance(tools, list)
-    assert len(tools) >= 20
+    assert isinstance(tools, Sequence)
+    assert tools
     names = {t.name for t in tools if getattr(t, "name", None)}
     assert "ping" in names
 

--- a/tests/test_remote_mcp_server.py
+++ b/tests/test_remote_mcp_server.py
@@ -158,7 +158,12 @@ class TestRemoteMCPServerStartup(unittest.TestCase):
                 result = remote_mcp_server.main()
 
                 # Verify mcp.run was called with correct transport
-                mock_mcp.run.assert_called_once_with(transport="streamable-http")
+                mock_mcp.run.assert_called_once_with(
+                    transport="streamable-http",
+                    host="0.0.0.0",
+                    port=8000,
+                    path="/mcp",
+                )
                 self.assertEqual(result, 0)
             except Exception:
                 # If we can't test the startup, at least verify config is correct

--- a/tests/test_slim_mode_integration.py
+++ b/tests/test_slim_mode_integration.py
@@ -172,12 +172,12 @@ class TestSLIMModeIntegration:
 
     async def get_available_tools(self, server) -> Set[str]:
         """Extract available tool names from server instance."""
-        # FastMCP 2.x: get_tools() -> dict. FastMCP 3.x: list_tools() -> Sequence[Tool].
-        if hasattr(server, "get_tools"):
-            tools_dict = await server.get_tools()
-            return set(tools_dict.keys())
-        tools_seq = await server.list_tools()
-        return {t.name for t in tools_seq if getattr(t, "name", None)}
+        # FastMCP 3.x: list_tools() -> Sequence[Tool]. FastMCP 2.x: get_tools() -> dict.
+        if hasattr(server, "list_tools"):
+            tools_seq = await server.list_tools()
+            return {t.name for t in tools_seq if getattr(t, "name", None)}
+        tools_dict = await server.get_tools()
+        return set(tools_dict.keys())
 
     @pytest.mark.asyncio
     async def test_slim_mode_reduces_tool_count(self, mcp_server_full_mode, mcp_server_slim_mode):


### PR DESCRIPTION
## Summary
- Phase 1 of [#177](https://github.com/aywengo/kafka-schema-reg-mcp/issues/177): mechanical FastMCP 2 → 3 catch-up now that `main` pins `fastmcp[tasks]>=3.2.0,<4` (3.4.7).
- Replace removed `BearerAuthProvider` with `JWTVerifier` (`AUTH_JWKS_URI` / default `{issuer}/.well-known/jwks.json`).
- Prefer `list_tools()` and pass `host`/`port`/`path` into `mcp.run()` for remote HTTP.

## Test plan
- [x] `uv run python -m pytest tests/test_fastmcp3_compat.py tests/test_slim_mode_integration.py tests/test_remote_mcp_server.py` (20 passed)
- [x] `./scripts/quick-lint-check.sh`
- [ ] CI Test Suite + Security Scan